### PR TITLE
Fix backwards-compat image build with repo-cached base images

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Check for Debos base image downloads
         run: | 
           [ -f action/neon_debos/base_images/download_base_images.py ] && \
-          python3 action/neon_debos/base_images/download_base_images.py
+          python3 action/neon_debos/base_images/download_base_images.py || echo "Using repo-cached base images"
       - name: Export keys for image build
         run: |
           mkdir -p action/neon_debos/overlays/80-google-json-overlay/home/neon/.local/share/neon


### PR DESCRIPTION
# Description
Troubleshooting backwards-compat with neon-debos cached base images

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Address failure https://github.com/NeonGeckoCom/neon-os/actions/runs/8088112113
Validated fix https://github.com/NeonDaniel/neon-os/actions/runs/8088189851/job/22101729501