### PR TITLE
Update to include release versions in outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 Neon OS releases can be primarily differentiated by a `core` version and
 an `image` version, where `core` refers to the repository providing the primary
 functionality (i.e. `neon-core` or `neon-nodes`) and `image` refers to code from
-the `neon_debos` repository. A particular OS release is identified by a version 
-string based on the time at which the release was compiled.
+the `neon_debos` repository. A particular OS release is identified by a
+`build version` string based on the time at which the release was compiled.
 
 ## Identifying Updates
-Updates are identified as OS releases with the same `core` and a newer timestamp.
+Updates are identified as OS releases with the same `core` and a newer 
+`build version`.
 
-An OS release is identified as a beta if EITHER the `core` or the `image` ref
-used is a beta. A device on a beta update track will only update to a newer
+A `build version` is marked as a beta if either the `core` or the `image` ref
+used is a beta (these will always be the same ref in automated builds). 
+A device on a beta update track will only update to a newer
 beta version; a device on a stable update track will only update to a newer
 stable version. If a device changes tracks, it will update to a NEWER release on
 the new track, but it will not install an older version by default.
@@ -17,13 +19,23 @@ the new track, but it will not install an older version by default.
 > beta track.
 
 ## Version Management
-Released images are identified by GitHub releases in this repository. The `yaml`
-index files may also be used to view release history per-image.
+Released images are identified in GitHub releases in this repository. The `yaml`
+index files may also be used to view release history per-image. Each yaml index
+entry has a `version` key that corresponds to a unique build; two builds may have
+the same `core` and `image` versions but different build versions based on when
+they were created.
 
 ### Versioning Scheme
 Releases will follow [CalVer](https://calver.org/), so a release version may be
 `24.02.14` or `24.02.14b1`. Note that the GitHub beta tags will *not* match the 
 associated images' versions for beta versions since each release may relate to a
 different `core`.
-> i.e. Neon OS tag `24.02.27.beta1` may contain `debian-neon-image-24.02.27b1` 
-> and Neon OS tag `24.02.27.beta2` may contain `debian-node-image-24.02.27b4`.
+> i.e. Neon OS tag `24.02.27.b1` may contain `debian-neon-image-24.02.27b1` 
+> and Neon OS tag `24.02.27.b2` may contain `debian-node-image-24.02.27b4`.
+
+## Glossary
+- `core`: the module/repository providing the primary functionality
+- `image`: the framework/repository building the OS image (`neon-debos`)
+- `build id`: `recipe`-`platform` string identifier (i.e. `debain-neon-image-rpi4`)
+- `build version`: the version identifier for a specific release image
+- `release`: a versioned release in the Neon OS repository.

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -35,8 +35,8 @@ output_dir=${5}  # /var/www/html/app/files/neon_images
 base_url=${6}  # https://2222.us
 os_dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 timestamp=$(date '+%Y-%m-%d_%H_%M')
-mem_limit=${MEM_LIMIT:-"64G"}
-core_limit=${CORE_LIMIT:-32}
+mem_limit=${MEM_LIMIT:-"32G"}
+core_limit=${CORE_LIMIT:-8}
 
 debos_version="$(python3 "${debos_dir}/version.py")"
 
@@ -46,6 +46,7 @@ chmod ugo+x "${debos_dir}/scripts/"*
 
 for platform in ${platforms}; do
   image_id="${recipe%.*}-${platform}_${timestamp}"
+  build_version=$(python3 "${os_dir}/scripts/get_build_version.py" "${recipe%.*}" "${platform}" "${repo_ref}" "${timestamp}")
   # TODO: Refactor builds to be platform-specific and not device-specific
   if [ "${platform}" == "rpi4" ]; then
     device="mark_2"
@@ -69,6 +70,7 @@ for platform in ${platforms}; do
   -t image:"${image_id}" \
   -t neon_core:"${repo_ref}" \
   -t neon_debos:"${debos_version}" \
+  -t build_version:"${build_version}" \
   -t build_cores:"${core_limit}" -m "${mem_limit}" -c "${core_limit}" || exit 2
   echo "Completed build: ${platform}"
 

--- a/scripts/get_build_version.py
+++ b/scripts/get_build_version.py
@@ -1,0 +1,66 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import yaml
+
+from sys import argv
+from os.path import dirname, join, isfile
+
+
+def get_version_for_build(build_id: str, beta: bool, time_str: str) -> str:
+    """
+    Get a version string for a build
+    :param build_id: {recipe}-{platform} identifier for this build
+    :param beta: if True, build is a beta
+    :param time_str: formatted date string to parse into a version string
+    :return: version string for this build
+    """
+    base_dir = dirname(dirname(__file__))
+    previous_beta = 0
+    try:
+        if isfile(join(base_dir, f"{build_id}.yaml")):
+            with open(join(base_dir, f"{build_id}.yaml")) as f:
+                build_info = yaml.safe_load(f)[0]
+            previous_beta = int(build_info['version'].split('b')[1])
+    except:
+        pass
+
+    base_version = time_str
+    if not beta:
+        return base_version
+    new_beta = previous_beta + 1
+    return f"{base_version}b{new_beta}"
+
+
+if __name__ == "__main__":
+    recipe = argv[1]
+    platform = argv[2]
+    beta = argv[3] == "dev"
+    timestamp = argv[4].split('_')[0][2:].replace('-', '.')
+    version = get_version_for_build(f"{recipe}-{platform}", beta, timestamp)
+    print(version)

--- a/scripts/update_metadata.py
+++ b/scripts/update_metadata.py
@@ -137,12 +137,13 @@ def write_changelog(new_images: List[dict]):
         else:
             beta = 1
 
-    title = f"# Neon OS Beta Release {date_ver}" if beta else \
+    title = f"# Neon OS Beta Release {date_ver}b{beta}" if beta else \
         f"# Neon OS Release {date_ver}"
     tag = f"{date_ver}b{beta}" if beta else date_ver
 
     release_strings = [(f"- [{image['image']} {image['version']}]"
                         f"({image['download']})\n") for image in new_images]
+    release_strings.sort()
     with open(release_notes, 'w') as f:
         f.writelines([f"{title}\n",
                       "This is an automated release\n\n",

--- a/scripts/update_metadata.py
+++ b/scripts/update_metadata.py
@@ -87,20 +87,21 @@ def update_build_indices(beta: bool) -> List[dict]:
         else:
             meta = list()
 
-        # Determine new version
-        val["version"] = datetime.fromtimestamp(
-            val["base_os"]["time"]).strftime("%y.%m.%d")
-        if beta and meta and "b" in meta[0]["version"]:
-            new_beta = int(meta[0]["version"].split("b")[1]) + 1
-            val["version"] = f'{val["version"]}b{new_beta}'
-        elif beta:
-            val["version"] = f'{val["version"]}b1'
+        if not val.get("build_version"):
+            # Determine new version
+            val["build_version"] = datetime.fromtimestamp(
+                val["base_os"]["time"]).strftime("%y.%m.%d")
+            if beta and meta and "b" in meta[0]["build_version"]:
+                new_beta = int(meta[0]["build_version"].split("b")[1]) + 1
+                val["build_version"] = f'{val["build_version"]}b{new_beta}'
+            elif beta:
+                val["build_version"] = f'{val["build_version"]}b1'
 
         # Add new builds to the top of the list
         meta.insert(0, val)
         all_meta.insert(0, val)
         new_images.append({"image": val['base_os']['name'],
-                           "version": val["version"],
+                           "version": val["build_version"],
                            "download": val['download_url']})
 
         with open(meta_file, 'w') as f:
@@ -138,7 +139,7 @@ def write_changelog(new_images: List[dict]):
 
     title = f"# Neon OS Beta Release {date_ver}" if beta else \
         f"# Neon OS Release {date_ver}"
-    tag = f"{date_ver}.beta{beta}" if beta else date_ver
+    tag = f"{date_ver}b{beta}" if beta else date_ver
 
     release_strings = [(f"- [{image['image']} {image['version']}]"
                         f"({image['download']})\n") for image in new_images]


### PR DESCRIPTION
# Description
Update image build to include `build_version` in output image metadata
Refactors `version` to `build_version` for consistency and clarity
Updates default core and memory limits to more reasonable maximums
Updates documentation to match implementation and add `Glossary` definitions

# Issues
Closes #3 

# Other Notes
Validated with https://github.com/NeonDaniel/neon-os/actions/runs/8116807951/job/22187626568