### PR TITLE
Fix bug with queued builds

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           repository: NeonGeckoCom/neon-os
           path: action/neon-os
+          ref: master
       - name: Run Neon OS Core Build
         if: env.DO_CORE == 'true'
         run: |


### PR DESCRIPTION
# Description
Specify `master` ref in neon-os repo checkout
This allows action runs to queue without subsequent runs failing

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Failure noted https://github.com/NeonGeckoCom/neon-os/actions/runs/8181975667/job/22372583735