### PR TITLE
Add optional core and debos branch overrides

### DIFF
--- a/.github/workflows/manual_release.yaml
+++ b/.github/workflows/manual_release.yaml
@@ -5,6 +5,12 @@ on:
       branch:
         type: string
         default: "dev"
+      core_branch:
+        type: string
+        default: None
+      debos_branch:
+        type: string
+        default: None
       repo:
         type: string
         default: "neon-debos"
@@ -20,5 +26,7 @@ jobs:
         client-payload: |-
           {
             "ref": "${{ inputs.branch }}",
-            "repo": "${{ inputs.repo }}"
+            "repo": "${{ inputs.repo }}",
+            "debos_ref": "${{ inputs.debos_branch }}"
+            "core_ref": "${{ inputs.core_branch }}"
           }

--- a/.github/workflows/manual_release.yaml
+++ b/.github/workflows/manual_release.yaml
@@ -27,6 +27,6 @@ jobs:
           {
             "ref": "${{ inputs.branch }}",
             "repo": "${{ inputs.repo }}",
-            "debos_ref": "${{ inputs.debos_branch }}"
+            "debos_ref": "${{ inputs.debos_branch }}",
             "core_ref": "${{ inputs.core_branch }}"
           }

--- a/.github/workflows/manual_release.yaml
+++ b/.github/workflows/manual_release.yaml
@@ -7,10 +7,10 @@ on:
         default: "dev"
       core_branch:
         type: string
-        default: None
+        default: ""
       debos_branch:
         type: string
-        default: None
+        default: ""
       repo:
         type: string
         default: "neon-debos"

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -18,6 +18,16 @@ jobs:
   build_images:
     runs-on: 2222.us
     steps:
+      - name: Log Job
+        run: |
+          echo "REF=${{env.REF}}" 
+          echo "DEBOS_REF=${{env.DEBOS_REF}}" 
+          echo "CORE_REF=${{env.CORE_REF}}" 
+          echo "PLATFORMS=${{env.PLATFORMS}}"
+          echo "UPLOAD_URL=${{env.UPLOAD_URL}}" 
+          echo "OUTPUT_DIR=${{env.OUTPUT_DIR}}" 
+          echo "DO_CORE=${{env.DO_CORE}}" 
+          echo "DO_NODE=${{env.DO_NODE}}"
       - name: Checkout Debos Repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -5,7 +5,9 @@ on:
       - Publish Release
 
 env:
-  REF: ${{ github.event.client_payload.ref }}
+  REF: ${{ github.event.client_payload.ref || 'dev' }}
+  DEBOS_REF: ${{ github.event.client_payload.debos_ref || github.event.client_payload.ref }}
+  CORE_REF: ${{ github.event.client_payload.core_ref || github.event.client_payload.ref }}
   PLATFORMS: "rpi4 opi5"
   UPLOAD_URL: "https://2222.us"
   OUTPUT_DIR: /var/www/html/app/files/neon_images
@@ -19,7 +21,7 @@ jobs:
       - name: Checkout Debos Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.REF }}
+          ref: ${{ env.DEBOS_REF }}
           repository: NeonGeckoCom/neon_debos
           path: action/neon_debos
           lfs: False
@@ -68,7 +70,7 @@ jobs:
         run: |
           bash "${{ github.workspace }}/action/neon-os/scripts/build_image.sh" \
           "${{ github.workspace }}/action/neon_debos" \
-          "${{env.REF}}" \
+          "${{env.CORE_REF}}" \
           "debian-neon-image.yml" \
           "${{env.PLATFORMS}}" \
           "${{env.OUTPUT_DIR}}" \
@@ -78,7 +80,7 @@ jobs:
         run: |
           bash "${{ github.workspace }}/action/neon-os/scripts/build_image.sh" \
           "${{ github.workspace }}/action/neon_debos" \
-          "${{env.REF}}" \
+          "${{env.CORE_REF}}" \
           "debian-node-image.yml" \
           "${{env.PLATFORMS}}" \
           "${{env.OUTPUT_DIR}}" \


### PR DESCRIPTION
# Description
Adds support for using a different core or debos branch
The existing `branch` parameter determines if the release is considered beta or stable

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This is useful for performing some final validation of a debos `dev` branch against other repositories' `master` branches or vice versa.

In the event core and recipe stable releases do not coincide, this allows for pushing a beta release with an existing stable version to allow for testing what will become the next stable release.

Validated https://github.com/NeonDaniel/neon-os/actions/runs/8574245445/job/23500636410