### PR TITLE
Remove LFS checkout of unused base images

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -35,30 +35,6 @@ jobs:
           repository: NeonGeckoCom/neon_debos
           path: action/neon_debos
           lfs: False
-      - name: Create LFS file list
-        run: |
-          cd action/neon_debos
-          git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-          cd ../..
-      - name: Restore LFS cache
-        uses: actions/cache@v3
-        id: lfs-cache
-        with:
-          path: action/neon_debos/.git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('action/neon_debos/.lfs-assets-id') }}-v1
-      - name: Ensure LFS files are pulled
-        if: steps.lfs-cache.outputs.cache-hit != 'true'
-        run: |
-          cd action/neon_debos
-          git lfs pull
-          cd ../..
-      - name: Save LFS Cache
-        if: steps.lfs-cache.outputs.cache-hit != 'true'
-        id: lfs-cache-save
-        uses: actions/cache/save@v3
-        with:
-          path: action/neon_debos/.git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('action/neon_debos/.lfs-assets-id') }}-v1
       - name: Check for Debos base image downloads
         run: | 
           [ -f action/neon_debos/base_images/download_base_images.py ] && \


### PR DESCRIPTION
# Description
Skip LFS checkout as base images are pulled manually from a file server now and not saved via git-lfs

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Related to Action timeout noted https://github.com/NeonGeckoCom/neon-os/actions/runs/9457132232