### PR TITLE
Add option to run `debos` without Docker

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -95,4 +95,9 @@ jobs:
           commit: ${{ github.ref }}
           prerelease: true
           bodyFile: "${{ github.workspace }}/action/neon-os/release_notes.md"
+      - name: Upload Build Logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: Debos logs
+          path: action/neon-os/*.log
 

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -107,7 +107,6 @@ for platform in ${platforms}; do
   if [ "${native_build}" == "true" ]; then
     echo "Waiting for ${platform} build to complete"
     wait
-    cat "${os_dir}/${platform}.log"
   else
     docker logs -f "neon_debos_ghaction_${platform}" || echo "${platform} container already exited"
   fi

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -77,7 +77,7 @@ for platform in ${platforms}; do
     -t neon_core:"${core_ref}" \
     -t neon_debos:"${debos_version}" \
     -t build_version:"${build_version}" \
-    -t build_cores:"${core_limit}" -m "${mem_limit}" -c "${core_limit}" > "${output_dir}/${platform}.log" 2>&1 &
+    -t build_cores:"${core_limit}" -m "${mem_limit}" -c "${core_limit}" > "${os_dir}/${platform}.log" 2>&1 &
   else
     docker run --rm -d \
     --device /dev/kvm \

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -104,7 +104,7 @@ for platform in ${platforms}; do
   if [ "${native_build}" == "true" ]; then
     echo "Waiting for ${platform} build to complete"
     wait
-    cat "${output_dir}/${platform}.log"
+    cat "${os_dir}/${platform}.log"
   else
     docker logs -f "neon_debos_ghaction_${platform}" || echo "${platform} container already exited"
   fi

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -68,7 +68,7 @@ for platform in ${platforms}; do
     kernel_version="5.10.110-gecko+"
   fi
   if [ "${native_build}" == "true" ]; then
-    debos "${recipe}" \
+    debos "${debos_dir}/${recipe}" \
     -t platform:"${platform}" \
     -t device:"${device}" \
     -t kernel_version:"${kernel_version}" \

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -35,6 +35,8 @@ output_dir=${5}  # /var/www/html/app/files/neon_images
 base_url=${6}  # https://2222.us
 build_ref=${7}  # RELEASE dev, master
 
+set -eE
+
 # Normalize build_ref
 if [[ "${build_ref}" == "master" || "${build_ref}" == "stable" ]]; then
   build_ref="master"
@@ -68,6 +70,7 @@ for platform in ${platforms}; do
     kernel_version="5.10.110-gecko+"
   fi
   if [ "${native_build}" == "true" ]; then
+    cd "${debos_dir}" || exit 2
     debos "${debos_dir}/${recipe}" \
     -t platform:"${platform}" \
     -t device:"${device}" \


### PR DESCRIPTION
# Description
Update image build to exit on errors
Update image build to use `debos` if available, instead of Docker
Upload debos outputs as artifacts if Docker not used

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->