### PR TITLE
Allow Build without KVM

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -45,7 +45,7 @@ else
 fi
 
 native_build=false
-which debos && native_build=true
+[ -e "$(which debos)" ] && native_build=true
 
 os_dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 timestamp=$(date '+%Y-%m-%d_%H_%M')
@@ -102,6 +102,7 @@ for platform in ${platforms}; do
   fi
 
   if [ "${native_build}" == "true" ]; then
+    echo "Native Build: ${platform}"
     cd "${debos_dir}" || exit 2
     debos "${debos_args[@]}" > "${os_dir}/${platform}.log" 2>&1 &
   else


### PR DESCRIPTION
# Description
Add check for `/dev/kvm` and build without fakemachine if not present
Docker support without kvm is implemented but untested

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
xcp-ng VMs have started crashing when using KVM backend. The cause of this issue is unknown, but nested virtualization is not well-documented or supported.

Validated: https://github.com/NeonGeckoCom/neon-os/actions/runs/11469527560